### PR TITLE
ignore Ctrl+Alt+key (i.e. AltGr+key) for escape sequences

### DIFF
--- a/crossline.c
+++ b/crossline.c
@@ -980,7 +980,7 @@ static int crossline_getkey (int *is_esc)
 		*is_esc = 1;
 		ch = crossline_getkey (&esc);
 		ch = crossline_key_esc2alt (ch);
-	} else if (GetKeyState (VK_MENU) & 0x8000) {
+	} else if (GetKeyState (VK_MENU) & 0x8000 && !(GetKeyState (VK_CONTROL) & 0x8000) ) {
 		*is_esc = 1; ch = ALT_KEY(ch);
 	}
 	return ch;


### PR DESCRIPTION
Hi! 

I really like your library, it's the easiest one to use and truly crossplatform!

I just had a small issue on my german keyboard on Windows. We use the right Alt key (labeled AltGr) for some special characters. For example '{' is AltGr+7, and '@' is AltGr+Q and so on... Which means I could not type this characters on my keyboard.

The AltGr key actually sets VK_MENU and VK_CONTROL (i.e. Ctrl+Alt) So I made the change to not map an escape sequence for this combination. It seems to work, the only downside is that the right alt key can't be used for keybords that have the AltGr key but we (German keyboar dusers) are used to not using it becuse of this.

Cheers,
Michael
